### PR TITLE
Multiproject arguments + restart command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,5 @@ All commands can be followed with `--help` for detailed instructions.
 | `dccm down [projectNames ...]`                  | Runs `docker-compose down --remove-orphans --volumes` command on a project(s). `[projectName]` defaults to current directory name.              |
 | `dccm start [projectNames ...]`                 | Runs `docker-compose start` command on a project(s). `[projectName]` defaults to current directory name.                                        |
 | `dccm stop [projectNames ...]`                  | Runs `docker-compose stop` command on a project(s). `[projectName]` defaults to current directory name.                                         |
+| `dccm restart [projectNames ...]`               | Runs `docker-compose restart` command on a project(s). `[projectName]` defaults to current directory name.                                      |
 | `dccm exec [projectName] [container] [command]` | Runs `docker-compose exec container command` command on a project. `[container]` and `[command]` values are persisted and can be later ommited. |

--- a/README.md
+++ b/README.md
@@ -22,18 +22,18 @@ This is required to be performed after each update.
 
 All commands can be followed with `--help` for detailed instructions.
 
-| Command               | Description |
-|-----------------------|-------------|
-| `dccm`, `dccm --help` | Displays help. |
-| `dccm completion --help` | Displays instructions on enabling shell autocompletion. |
-| `dccm list` | Lists all saved projects. |
-| `dccm add [projectName]` | Adds `docker-compose.yml` file from current directory to specified project. `[projectName]` defaults to current directory name..|
-| `dccm add [projectName] [file]` | Adds specified file to the specified project. |
-| `dccm status` | Prints out statuses of all projects. |
-| `dccm status [projectName]` | Prints out status of a specified project. |
-| `dccm remove [projectName]` | Removes a project from saved projects. |
-| `dccm up [projectName]` | Runs `docker-compose up -d` command on a project. `[projectName]` defaults to current directory name. |
-| `dccm down [projectName]` | Runs `docker-compose down --remove-orphans --volumes` command on a project. `[projectName]` defaults to current directory name. |
-| `dccm start [projectName]` | Runs `docker-compose start` command on a project. `[projectName]` defaults to current directory name. |
-| `dccm stop [projectName]` | Runs `docker-compose stop` command on a project. `[projectName]` defaults to current directory name. |
+| Command                                         | Description                                                                                                                                     |
+|-------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+| `dccm`, `dccm --help`                           | Displays help.                                                                                                                                  |
+| `dccm completion --help`                        | Displays instructions on enabling shell autocompletion.                                                                                         |
+| `dccm list`                                     | Lists all saved projects.                                                                                                                       |
+| `dccm add [projectName]`                        | Adds `docker-compose.yml` file from current directory to specified project. `[projectName]` defaults to current directory name..                |
+| `dccm add [projectName] [file]`                 | Adds specified file to the specified project.                                                                                                   |
+| `dccm status`                                   | Prints out statuses of all projects.                                                                                                            |
+| `dccm status [projectName]`                     | Prints out status of a specified project.                                                                                                       |
+| `dccm remove [projectName]`                     | Removes a project from saved projects.                                                                                                          |
+| `dccm up [projectNames ...]`                    | Runs `docker-compose up -d` command on a project(s). `[projectName]` defaults to current directory name.                                        |
+| `dccm down [projectNames ...]`                  | Runs `docker-compose down --remove-orphans --volumes` command on a project(s). `[projectName]` defaults to current directory name.              |
+| `dccm start [projectNames ...]`                 | Runs `docker-compose start` command on a project(s). `[projectName]` defaults to current directory name.                                        |
+| `dccm stop [projectNames ...]`                  | Runs `docker-compose stop` command on a project(s). `[projectName]` defaults to current directory name.                                         |
 | `dccm exec [projectName] [container] [command]` | Runs `docker-compose exec container command` command on a project. `[container]` and `[command]` values are persisted and can be later ommited. |

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ require (
 	github.com/spf13/cobra v1.2.1
 	go.etcd.io/bbolt v1.3.6
 	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
-	golang.org/x/tools v0.1.9 // indirect
+	golang.org/x/tools v0.1.10 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -244,6 +244,7 @@ golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -279,7 +280,7 @@ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.5.1/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
+golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3/go.mod h1:3p9vT2HGsQu2K1YbXdKPJLVgG5VJdoTa1poYQBtP1AY=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181023162649-9b4f9f5ad519/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -383,6 +384,7 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 h1:id054HUawV2/6IGm2IV8KZQjqtwAOo2CYlOToYqa0d0=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -449,8 +451,8 @@ golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools v0.1.9 h1:j9KsMiaP1c3B0OTQGth0/k+miLGTgLsAFUCrF2vLcF8=
-golang.org/x/tools v0.1.9/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
+golang.org/x/tools v0.1.10 h1:QjFRCZxdOhBJ/UNgnBZLbNV13DlbnK0quyivTnXJM20=
+golang.org/x/tools v0.1.10/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/src/command/dcfDown.go
+++ b/src/command/dcfDown.go
@@ -8,13 +8,19 @@ var dfcDownCommand = &cobra.Command{
 	Use:   "down [project-name]",
 	Short: "Removes docker-compose set",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		dcFiles, err := getDcFilesFromCommandArguments(args)
+		dcProjects, err := getDcProjectsFromCommandArguments(args)
 		if err != nil {
 			return err
 		}
-		return manager.DockerComposeDown(dcFiles)
+		for _, aProject := range dcProjects {
+			err = manager.DockerComposeDown(aProject)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
 	},
-	ValidArgsFunction: projectNamesAutocompletion,
+	ValidArgsFunction: projectNamesMultipleAutocompletion,
 }
 
 func init() {

--- a/src/command/dcfDown_test.go
+++ b/src/command/dcfDown_test.go
@@ -25,7 +25,7 @@ func TestDcfDownCommand_FilesError(t *testing.T) {
 
 	err := dfcDownCommand.RunE(fakeCommand, oneArgument)
 
-	tests.AssertErrorEquals(t, "files error", err)
+	tests.AssertErrorEquals(t, "no files to execute", err)
 	tests.AssertIntEquals(t, 0, len(argumentDockerComposeDown), "TestDcfDownCommand_FilesError")
 }
 

--- a/src/command/dcfRestart.go
+++ b/src/command/dcfRestart.go
@@ -1,0 +1,28 @@
+package command
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var dfcRestartCommand = &cobra.Command{
+	Use:   "restart [project-name]",
+	Short: "Restarts docker-compose set",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dcProjects, err := getDcProjectsFromCommandArguments(args)
+		if err != nil {
+			return err
+		}
+		for _, aProject := range dcProjects {
+			err = manager.DockerComposeRestart(aProject)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	},
+	ValidArgsFunction: projectNamesMultipleAutocompletion,
+}
+
+func init() {
+	RootCommand.AddCommand(dfcRestartCommand)
+}

--- a/src/command/dcfRestart_test.go
+++ b/src/command/dcfRestart_test.go
@@ -1,0 +1,41 @@
+package command
+
+import (
+	docker_compose_manager "docker-compose-manager/src/docker-compose-manager"
+	"docker-compose-manager/src/tests"
+	"errors"
+	"testing"
+)
+
+func TestDcfRestartCommand(t *testing.T) {
+	setupTest()
+	resultGetDockerComposeFilesByProject = docker_compose_manager.DockerComposeProject{docker_compose_manager.InitDockerComposeFile("dcFile.yml")}
+
+	err := dfcRestartCommand.RunE(fakeCommand, oneArgument)
+
+	tests.AssertNil(t, err, "Start command")
+
+	tests.AssertIntEquals(t, 1, len(argumentDockerComposeRestart), "TestDcfRestartCommand")
+	tests.AssertStringEquals(t, "dcFile.yml", argumentDockerComposeRestart[0].GetFilename(), "TestDcfRestartCommand")
+}
+
+func TestDcfRestartCommand_FilesError(t *testing.T) {
+	setupTest()
+	resultGetDockerComposeFilesByProjectError = errors.New("files error")
+
+	err := dfcRestartCommand.RunE(fakeCommand, oneArgument)
+
+	tests.AssertErrorEquals(t, "no files to execute", err)
+	tests.AssertIntEquals(t, 0, len(argumentDockerComposeRestart), "TestDcfRestartCommand_FilesError")
+}
+
+func TestDcfRestartCommand_Error(t *testing.T) {
+	setupTest()
+	resultGetDockerComposeFilesByProject = docker_compose_manager.DockerComposeProject{docker_compose_manager.InitDockerComposeFile("dcFile.yml")}
+	resultDockerComposeRestart = errors.New("result error")
+
+	err := dfcRestartCommand.RunE(fakeCommand, oneArgument)
+
+	tests.AssertErrorEquals(t, "result error", err)
+	tests.AssertIntEquals(t, 1, len(argumentDockerComposeRestart), "TestDcfRestartCommand_Error")
+}

--- a/src/command/dcfStart.go
+++ b/src/command/dcfStart.go
@@ -8,13 +8,19 @@ var dfcStartCommand = &cobra.Command{
 	Use:   "start [project-name]",
 	Short: "Starts docker-compose set",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		dcFiles, err := getDcFilesFromCommandArguments(args)
+		dcProjects, err := getDcProjectsFromCommandArguments(args)
 		if err != nil {
 			return err
 		}
-		return manager.DockerComposeStart(dcFiles)
+		for _, aProject := range dcProjects {
+			err = manager.DockerComposeStart(aProject)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
 	},
-	ValidArgsFunction: projectNamesAutocompletion,
+	ValidArgsFunction: projectNamesMultipleAutocompletion,
 }
 
 func init() {

--- a/src/command/dcfStart_test.go
+++ b/src/command/dcfStart_test.go
@@ -25,7 +25,7 @@ func TestDcfStartCommand_FilesError(t *testing.T) {
 
 	err := dfcStartCommand.RunE(fakeCommand, oneArgument)
 
-	tests.AssertErrorEquals(t, "files error", err)
+	tests.AssertErrorEquals(t, "no files to execute", err)
 	tests.AssertIntEquals(t, 0, len(argumentDockerComposeStart), "TestDcfStartCommand_FilesError")
 }
 

--- a/src/command/dcfStop.go
+++ b/src/command/dcfStop.go
@@ -8,13 +8,19 @@ var dfcStopCommand = &cobra.Command{
 	Use:   "stop [project-name]",
 	Short: "Stops docker-compose set",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		dcFiles, err := getDcFilesFromCommandArguments(args)
+		dcProjects, err := getDcProjectsFromCommandArguments(args)
 		if err != nil {
 			return err
 		}
-		return manager.DockerComposeStop(dcFiles)
+		for _, aProject := range dcProjects {
+			err = manager.DockerComposeStop(aProject)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
 	},
-	ValidArgsFunction: projectNamesAutocompletion,
+	ValidArgsFunction: projectNamesMultipleAutocompletion,
 }
 
 func init() {

--- a/src/command/dcfStop_test.go
+++ b/src/command/dcfStop_test.go
@@ -25,7 +25,7 @@ func TestDcfStopCommand_FilesError(t *testing.T) {
 
 	err := dfcStopCommand.RunE(fakeCommand, oneArgument)
 
-	tests.AssertErrorEquals(t, "files error", err)
+	tests.AssertErrorEquals(t, "no files to execute", err)
 	tests.AssertIntEquals(t, 0, len(argumentDockerComposeStop), "TestDcfStopCommand_FilesError")
 }
 

--- a/src/command/dcfUp.go
+++ b/src/command/dcfUp.go
@@ -8,13 +8,19 @@ var dfcUpCommand = &cobra.Command{
 	Use:   "up [project-name]",
 	Short: "Creates docker-compose set",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		dcFiles, err := getDcFilesFromCommandArguments(args)
+		dcProjects, err := getDcProjectsFromCommandArguments(args)
 		if err != nil {
 			return err
 		}
-		return manager.DockerComposeUp(dcFiles)
+		for _, aProject := range dcProjects {
+			err = manager.DockerComposeUp(aProject)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
 	},
-	ValidArgsFunction: projectNamesAutocompletion,
+	ValidArgsFunction: projectNamesMultipleAutocompletion,
 }
 
 func init() {

--- a/src/command/dcfUp_test.go
+++ b/src/command/dcfUp_test.go
@@ -25,7 +25,7 @@ func TestDcfUpCommand_FilesError(t *testing.T) {
 
 	err := dfcUpCommand.RunE(fakeCommand, oneArgument)
 
-	tests.AssertErrorEquals(t, "files error", err)
+	tests.AssertErrorEquals(t, "no files to execute", err)
 	tests.AssertIntEquals(t, 0, len(argumentDockerComposeUp), "TestDcfUpCommand_FilesError")
 }
 

--- a/src/command/main.go
+++ b/src/command/main.go
@@ -12,6 +12,7 @@ type DockerComposeManagerInterface interface {
 	DockerComposeExec(files dcm.DockerComposeProject, params dcm.ProjectExecConfigInterface) error
 	DockerComposeUp(files dcm.DockerComposeProject) error
 	DockerComposeStart(files dcm.DockerComposeProject) error
+	DockerComposeRestart(files dcm.DockerComposeProject) error
 	DockerComposeStop(files dcm.DockerComposeProject) error
 	DockerComposeDown(files dcm.DockerComposeProject) error
 	DockerComposeStatus(files dcm.DockerComposeProject) dcm.DockerComposeFileStatus

--- a/src/command/main.go
+++ b/src/command/main.go
@@ -27,6 +27,30 @@ func InitCommands(managerInstance DockerComposeManagerInterface, writer io.Write
 	mainWriter = writer
 }
 
+func getDcProjectsFromCommandArguments(args []string) ([]dcm.DockerComposeProject, error) {
+	var dcProject dcm.DockerComposeProject
+	var dcProjects []dcm.DockerComposeProject
+	var err error
+
+	if len(args) == 0 {
+		dcProject, err = guessDcProjectFromCurrentDirectory()
+		dcProjects = append(dcProjects, dcProject)
+	} else {
+		for _, argument := range args {
+			dcProject, err = manager.GetConfigFile().GetDockerComposeFilesByProject(argument)
+			if err == nil {
+				dcProjects = append(dcProjects, dcProject)
+			}
+		}
+	}
+
+	if len(dcProjects) == 0 {
+		return nil, errors.New("no files to execute")
+	}
+
+	return dcProjects, nil
+}
+
 func getDcFilesFromCommandArguments(args []string) (dcm.DockerComposeProject, error) {
 	var dcFiles dcm.DockerComposeProject
 
@@ -63,10 +87,35 @@ func getDcFilesFromCommandArguments(args []string) (dcm.DockerComposeProject, er
 	return dcFiles, nil
 }
 
+func guessDcProjectFromCurrentDirectory() (dcm.DockerComposeProject, error) {
+	var dcFiles dcm.DockerComposeProject
+
+	currDir, cdErr := manager.GetFileInfoProvider().GetCurrentDirectory()
+	if cdErr != nil {
+		return nil, cdErr
+	}
+	dcFilePath, err := manager.LocateFileInDirectory(currDir)
+	if err != nil {
+		return nil, err
+	}
+	dcmFile := dcm.InitDockerComposeFile(dcFilePath)
+
+	return append(dcFiles, dcmFile), nil
+}
+
 func projectNamesAutocompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if len(args) != 0 {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
+
+	return getAutocompletion(cmd, args, toComplete)
+}
+
+func projectNamesMultipleAutocompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return getAutocompletion(cmd, args, toComplete)
+}
+
+func getAutocompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	projects, err := manager.GetConfigFile().GetDockerComposeProjectList(toComplete)
 
 	if err != nil {

--- a/src/command/main_test.go
+++ b/src/command/main_test.go
@@ -103,6 +103,8 @@ var argumentDockerComposeUp docker_compose_manager.DockerComposeProject
 var resultDockerComposeUp error
 var argumentDockerComposeStart docker_compose_manager.DockerComposeProject
 var resultDockerComposeStart error
+var argumentDockerComposeRestart docker_compose_manager.DockerComposeProject
+var resultDockerComposeRestart error
 var argumentDockerComposeStop docker_compose_manager.DockerComposeProject
 var resultDockerComposeStop error
 var argumentDockerComposeDown docker_compose_manager.DockerComposeProject
@@ -130,6 +132,11 @@ func (f fakeManager) DockerComposeUp(files docker_compose_manager.DockerComposeP
 func (f fakeManager) DockerComposeStart(files docker_compose_manager.DockerComposeProject) error {
 	argumentDockerComposeStart = files
 	return resultDockerComposeStart
+}
+
+func (f fakeManager) DockerComposeRestart(files docker_compose_manager.DockerComposeProject) error {
+	argumentDockerComposeRestart = files
+	return resultDockerComposeRestart
 }
 
 func (f fakeManager) DockerComposeStop(files docker_compose_manager.DockerComposeProject) error {
@@ -190,6 +197,8 @@ func setupTest() {
 	resultGetExecConfigByProjectError = nil
 	resultGetExecConfigByProjectConfig = docker_compose_manager.InitProjectExecConfig("", "")
 	resultDockerComposeExec = nil
+	argumentDockerComposeRestart = nil
+	resultDockerComposeRestart = nil
 
 	noArguments = []string{}
 	oneArgument = []string{"firstArg"}

--- a/src/docker-compose-manager/docker-compose-manager.go
+++ b/src/docker-compose-manager/docker-compose-manager.go
@@ -60,6 +60,10 @@ func (d *DockerComposeManager) DockerComposeUp(files DockerComposeProject) error
 	return d.runCommand("up", files, []string{"-d"})
 }
 
+func (d *DockerComposeManager) DockerComposeRestart(files DockerComposeProject) error {
+	return d.runCommand("restart", files, []string{})
+}
+
 func (d *DockerComposeManager) DockerComposeStart(files DockerComposeProject) error {
 	return d.runCommand("start", files, []string{})
 }
@@ -106,7 +110,7 @@ func (d *DockerComposeManager) LocateFileInDirectory(dir string) (string, error)
 func (d *DockerComposeManager) getRunningServicesCount(files DockerComposeProject) (int, int, error) {
 	bufReader, runningError := d.getRunningServices(files)
 	if runningError != nil {
-		return 0,0, runningError
+		return 0, 0, runningError
 	}
 	totalCount := 0
 	upCount := 0

--- a/src/docker-compose-manager/docker-compose-manager_test.go
+++ b/src/docker-compose-manager/docker-compose-manager_test.go
@@ -29,7 +29,7 @@ var argumentGetExecConfigByProject string
 var resultGetExecConfigByProjectContainer string
 var resultGetExecConfigByProjectCommand string
 
-var argumentSaveExecConfigConfig ProjectExecConfigInterface 
+var argumentSaveExecConfigConfig ProjectExecConfigInterface
 var argumentSaveExecConfigString string
 var resultSaveExecConfig error
 
@@ -54,7 +54,7 @@ func (f fakeConfiguration) DeleteProjectByName(name string) error {
 	return resultDeleteProjectByNameError
 }
 
-func (f fakeConfiguration) GetExecConfigByProject(projectName string) (ProjectExecConfig, error){
+func (f fakeConfiguration) GetExecConfigByProject(projectName string) (ProjectExecConfig, error) {
 	argumentGetExecConfigByProject = projectName
 	return InitProjectExecConfig(resultGetExecConfigByProjectContainer, resultGetExecConfigByProjectCommand), nil
 }
@@ -531,6 +531,27 @@ func TestDockerComposeManager_DockerComposeStop(t *testing.T) {
 	}
 }
 
+func TestDockerComposeManager_DockerComposeRestart(t *testing.T) {
+	dcm, project, _ := createDefaultObjects()
+	resultRunCommandError = nil
+
+	dcm.DockerComposeRestart(project)
+
+	if argumentRunCommandCommand != "docker-compose" {
+		t.Errorf("Invalid command run. Expected %s got %s", "docker-compose", argumentRunCommandCommand)
+	}
+
+	if len(argumentRunCommandArgs) != 5 {
+		t.Errorf("Invalid command run arguments. Expected %d got %d", 5, len(argumentRunCommandArgs))
+	}
+
+	checkFilenamesArguments(t, argumentRunCommandArgs, 0)
+
+	if argumentRunCommandArgs[4] != "restart" {
+		t.Errorf("Invalid argument no. %d. Expected %s, got %s", 5, "stop", argumentRunCommandArgs[4])
+	}
+}
+
 func getCountCommandResults(totalLines int, running int) []byte {
 	result := []byte("   Name               Command           State    Ports\n-------------------------------------------------------")
 	for l := 1; l <= totalLines; l++ {
@@ -601,7 +622,7 @@ func TestDockerComposeManager_DockerComposeExec(t *testing.T) {
 	dcm.DockerComposeExec(project, config)
 
 	tests.AssertStringEquals(t, argumentRunCommandCommand, "docker-compose", "TestDockerComposeManager_DockerComposeExec_command")
-	if (len(argumentRunCommandArgs) != 7) {
+	if len(argumentRunCommandArgs) != 7 {
 		t.Errorf("Invalid TestDockerComposeManager_DockerComposeExec argument count. Expected %d, got %d", 7, len(argumentRunCommandArgs))
 	}
 


### PR DESCRIPTION
Allowed multiple projects in arguments to batch run `start`, `stop`, `up`, and `down` commands as well as the newly created `restart` one.